### PR TITLE
Supp edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,25 @@
-# Denoiser-Comparison
 ## About
-   The aim of this project is to compare the results from three different Illumina 454 sequence denoising pipelines.
-   The three pipelines are:
-       [DADA2](https://benjjneb.github.io/dada2/)
-       [UNOISE3](https://www.drive5.com/usearch/manual/cmd_unoise3.html)
-       [Deblur](https://github.com/biocore/deblur).
-   None of the raw data is contained within this repository.
+The aim of this project is to compare the results from three different Illumina sequence denoising pipelines.
+  
+The three pipelines are:
+* [DADA2](https://benjjneb.github.io/dada2/)
+* [UNOISE3](https://www.drive5.com/usearch/manual/cmd_unoise3.html)
+* [Deblur](https://github.com/biocore/deblur)
+
+None of the raw sequencing data is contained within this repository.
+
 ### Blast_db
 Contains all scripts used to modify any of the Database files
 All Databases were generated using blast tools
+
 ### Config
 Cotains all the configuration files to run the different pipelines
+
 ### Data_Analysis
-Contains all scripts that were used stricktly for the analysis of the resulting ASV from the pipelines
+Contains all scripts that were used strictly for the analysis of the resulting amplicon sequence variants from the pipelines
+
 ### Pipeline_Scripts
 Contains the scripts that were used to run the three different pipelines
+
 ### Rscripts
 Contains all the Rscripts that were used to generate plots as well as assign taxonomy.

--- a/Rscripts/bray_curtis_exploring.R
+++ b/Rscripts/bray_curtis_exploring.R
@@ -8,6 +8,8 @@ par(xpd = NA, # switch off clipping, necessary to always see axis labels
     bg = "transparent", # switch off background to avoid obscuring adjacent plots
     oma = c(2, 2, 0, 0)) # move plot to the right and up
 
+################## Commands for exploring blueberry results ##################
+
 setwd("/home/jacob/projects/DenoiseCompare_Out/Blueberry/med/COMBINED/bray_curtis/")
 
 in_tab <- read.table("tax_sum/merged_blueberry_taxa_L6.txt",
@@ -111,6 +113,79 @@ plot_grid(Bacteria_Unclassified,
           labels="AUTO",
           nrow=2,
           ncol=3)
+
+
+################## Commands for exploring BISCUIT results ##################
+
+in_tab_biscuit <- read.table("../../../../biscuit/med/COMBINED/Tax_Sum/Combined_biscuit_taxa_L6.txt",
+                     header=T,
+                     comment.char="",
+                     skip=1,
+                     sep="\t",
+                     stringsAsFactors = FALSE,
+                     row.names=1)
+
+# Split by each pipeline.
+dada_tab_biscuit <- in_tab_biscuit[, grep("Dada", colnames(in_tab_biscuit))]
+deblur_tab_biscuit <- in_tab_biscuit[, grep("Deblur", colnames(in_tab_biscuit))]
+unoise_tab_biscuit <- in_tab_biscuit[, grep("Unoise", colnames(in_tab_biscuit))]
+
+dada_tab_biscuit_means <- rowMeans(dada_tab_biscuit)
+deblur_tab_biscuit_means <- rowMeans(deblur_tab_biscuit)
+unoise_tab_biscuit_means <- rowMeans(unoise_tab_biscuit)
+
+hist(dada_tab_biscuit_means - deblur_tab_biscuit_means, xlim=c(-0.03,0.03), ylim=c(0, 100), breaks=100, main="", xlab="DADA2 - Deblur",  col="grey")
+dada_v_deblur_genera_diff_biscuit <- recordPlot()
+
+hist(dada_tab_biscuit_means - unoise_tab_biscuit_means, xlim=c(-0.03,0.03), ylim=c(0, 100), breaks=50, main="", xlab="DADA2 - UNOISE3", col="grey")
+dada_v_unoise_genera_diff_biscuit <- recordPlot()
+
+hist(deblur_tab_biscuit_means - unoise_tab_biscuit_means, xlim=c(-0.03,0.03), ylim=c(0, 100), breaks=100, main="", xlab="Deblur - UNOISE3",  col="grey")
+deblur_v_unoise_genera_diff_biscuit <- recordPlot()
+
+plot_grid(dada_v_deblur_genera_diff_biscuit,
+          dada_v_unoise_genera_diff_biscuit,
+          deblur_v_unoise_genera_diff_biscuit,
+          labels="AUTO")
+
+dada_deblur_diff_biscuit <- dada_tab_biscuit_means - deblur_tab_biscuit_means
+unoise_deblur_diff_biscuit <- unoise_tab_biscuit_means - deblur_tab_biscuit_means
+unoise_dada_diff_biscuit <- unoise_tab_biscuit_means - dada_tab_biscuit_means
+
+which(abs(unoise_deblur_diff_biscuit) > 0.005)
+which(abs(dada_deblur_diff_biscuit) > 0.005)
+
+### The 2 overlapping both are:
+#Bacteria;Firmicutes;Clostridia;Clostridiales;Lachnospiraceae;Unclassified 
+#72 
+#Bacteria;Proteobacteria;Gammaproteobacteria;Enterobacteriales;Enterobacteriaceae;Escherichia/Shigella 
+#146 
+
+boxplot(as.numeric(dada_tab_biscuit[72,]), 
+        as.numeric(deblur_tab_biscuit[72,]),
+        as.numeric(unoise_tab_biscuit[72,]),
+        names = c("Dada", "Deblur", "Unoise"),
+        ylab = "Bacteria;Firmicutes;Clostridia;Clostridiales;Lachnospiraceae;Unclassified",
+        ylim=c(0,0.23))
+
+Lachnospiraceae_boxplot <- recordPlot()
+
+boxplot(as.numeric(dada_tab_biscuit[146,]), 
+        as.numeric(deblur_tab_biscuit[146,]),
+        as.numeric(unoise_tab_biscuit[146,]),
+        names = c("Dada", "Deblur", "Unoise"),
+        ylab = "Bacteria;Proteobacteria;Gammaproteobacteria;Enterobacteriales;Enterobacteriaceae;Escherichia/Shigella",
+        ylim=c(0,0.6))
+
+Ecoli_boxplot <- recordPlot()
+
+plot_grid(Lachnospiraceae_boxplot,
+          Ecoli_boxplot,
+          labels="AUTO",
+          nrow=1,
+          ncol=2)
+
+################## The below commented out commands were used for exploring the data, but not for making supplementary figures ################## 
 
 # One sample's rel. abundance in terms of classified and unclassified genera
 #all_unclassified <- grep("Unclassified", rownames(in_tab))


### PR DESCRIPTION
Made minor changes to README and added R commands for exploring genera outliers in BISCUIT validation dataset. The two main outliers are:

1) Bacteria;Firmicutes;Clostridia;Clostridiales;Lachnospiraceae;Unclassified, which is lower in deblur output

2) Bacteria;Proteobacteria;Gammaproteobacteria;Enterobacteriales;Enterobacteriaceae;Escherichia/Shigella, which is higher in deblur output

I think these are important to highlight since it disagrees with the result from the blueberry dataset which indicated that it was the unclassified taxa called by deblur that were contributing most to the difference in bray-curtis distances... we can't say the same here! I'm not sure if the boxplots are necessary (we could just mention what the main outliers were).
